### PR TITLE
Fixes for several exceptions

### DIFF
--- a/Source/AntennaHelper/AHFlight.cs
+++ b/Source/AntennaHelper/AHFlight.cs
@@ -143,6 +143,8 @@ namespace AntennaHelper
 
 		private void SetRelayList ()
 		{
+			Relay.UpdateRelayVessels ();
+
 			relays = new Dictionary<Vessel, LinkPath> ();
 
 			foreach (Vessel relay in FlightGlobals.Vessels.FindAll 

--- a/Source/AntennaHelper/AHFlight.cs
+++ b/Source/AntennaHelper/AHFlight.cs
@@ -28,8 +28,8 @@ namespace AntennaHelper
 
 		Dictionary<Vessel, LinkPath> relays;
 
-		Dictionary<Vessel, AHMapMarker> markersRelay;
-		AHMapMarker markerDSN;
+		Dictionary<Vessel, GameObject> markerObjectsRelay;
+		GameObject markerObjectDSN;
 
 		private float timeAtStart;
 		private bool hasStarted = false;
@@ -173,34 +173,36 @@ namespace AntennaHelper
 
 		private IEnumerator SetMarkerList ()
 		{
-			markerDSN = CreateMapMarkerDSN ();
+			markerObjectDSN = CreateMapMarkerDSN ();
 
-			markersRelay = new Dictionary<Vessel, AHMapMarker> ();
+			markerObjectsRelay = new Dictionary<Vessel, GameObject> ();
 
 			foreach (KeyValuePair<Vessel, LinkPath> relay in relays) {
 				yield return timers [0];
-				markersRelay.Add (relay.Key, CreateMapMarkerRelay (relay.Key));
+				markerObjectsRelay.Add (relay.Key, CreateMapMarkerRelay (relay.Key));
 			}
 
 		}
 
-		private AHMapMarker CreateMapMarkerRelay (Vessel relay)
+		private GameObject CreateMapMarkerRelay (Vessel relay)
 		{
 			double realSignal = relays [relay].endRelaySignalStrength;//AHUtil.GetREALSignal (relay.Connection.ControlPath);
 			double range = AHUtil.GetDistanceAt0 
 							(AHUtil.GetRange (vesselPower, relays [relay].endRelayPower));
-			AHMapMarker marker = new GameObject ().AddComponent<AHMapMarker> ();
+			GameObject markerObject = new GameObject ();
+			AHMapMarker marker = markerObject.AddComponent<AHMapMarker> ();
 			marker.SetUp (range, vessel, relay.mapObject.trf, false, realSignal);
 
 
-			return marker;
+			return markerObject;
 		}
 
-		private AHMapMarker CreateMapMarkerDSN ()
+		private GameObject CreateMapMarkerDSN ()
 		{
-			AHMapMarker marker = new GameObject ().AddComponent<AHMapMarker> ();
+			GameObject markerObject = new GameObject ();
+			AHMapMarker marker = markerObject.AddComponent<AHMapMarker> ();
 			marker.SetUp (dsnRange, vessel, dsnBody.MapObject.trf, true, 1d);
-			return marker;
+			return markerObject;
 		}
 		#endregion
 
@@ -227,14 +229,14 @@ namespace AntennaHelper
 
 		private void DestroyMarkers ()
 		{
-			if (markerDSN != null) {
-				Destroy (markerDSN.gameObject);
+			if (markerObjectDSN != null) {
+				Destroy (markerObjectDSN);
 			}
 
-			if (markersRelay != null) {
-				foreach (KeyValuePair<Vessel, AHMapMarker> marker in markersRelay) {
-					if (marker.Value != null) {
-						Destroy (marker.Value.gameObject);
+			if (markerObjectsRelay != null) {
+				foreach (KeyValuePair<Vessel, GameObject> markerObject in markerObjectsRelay) {
+					if (markerObject.Value != null) {
+						Destroy (markerObject.Value);
 					}
 
 				}
@@ -261,10 +263,10 @@ namespace AntennaHelper
 				Debug.Log ("[AH] a relay vessel is destroyed, named : " + v.GetName ());
 				relays.Remove (v);
 			}
-			if ((markersRelay != null) && (markersRelay.ContainsKey (v))) {
+			if ((markerObjectsRelay != null) && (markerObjectsRelay.ContainsKey (v))) {
 				Debug.Log ("[AH] a vessel with its AH map marker is destroyed, named : " + v.GetName ());
-				Destroy (markersRelay[v].gameObject);
-				markersRelay.Remove (v);
+				Destroy (markerObjectsRelay [v]);
+				markerObjectsRelay.Remove (v);
 			}
 
 			if (vessel == null)
@@ -312,10 +314,11 @@ namespace AntennaHelper
 				{
 //					relaySS = AHUtil.GetREALSignal (relay.Connection.ControlPath);
 
-					if ((relays [relay].endRelaySignalStrength > markersRelay [relay].scale + .01d) 
-						|| (relays [relay].endRelaySignalStrength < markersRelay [relay].scale - .01d))
+					AHMapMarker marker = markerObjectsRelay [relay].GetComponent<AHMapMarker> ();
+					if ((relays [relay].endRelaySignalStrength > marker.scale + .01d) 
+						|| (relays [relay].endRelaySignalStrength < marker.scale - .01d))
 					{
-						markersRelay [relay].SetScale (relays [relay].endRelaySignalStrength);
+						marker.SetScale (relays [relay].endRelaySignalStrength);
 					}
 					yield return timers [0];
 				}

--- a/Source/AntennaHelper/AHFlightWindow.cs
+++ b/Source/AntennaHelper/AHFlightWindow.cs
@@ -412,7 +412,7 @@ namespace AntennaHelper
 				} else if (connectedTo != null) {
 					ShowDSNCircles (false);
 					ShowRelaysCircles (false);
-					markersRelay [connectedTo].Show ();
+					markerObjectsRelay [connectedTo].GetComponent<AHMapMarker> ().Show ();
 				}
 				guiStyleSelectDSN = guiStyleButtonNorm;
 				guiStyleSelectRelay = guiStyleButtonNorm;
@@ -436,21 +436,21 @@ namespace AntennaHelper
 		private void ShowDSNCircles (bool show = true)
 		{
 			if (show) {
-				markerDSN.Show ();
+				markerObjectDSN.GetComponent<AHMapMarker> ().Show ();
 			} else {
-				markerDSN.Hide ();
+				markerObjectDSN.GetComponent<AHMapMarker> ().Hide ();
 			}
 		}
 
 		private void ShowRelaysCircles (bool show = true)
 		{
 			if (show) {
-				foreach (KeyValuePair<Vessel, AHMapMarker> relayMarkers in markersRelay) {
-					relayMarkers.Value.Show ();
+				foreach (KeyValuePair<Vessel, GameObject> relayMarkerObjects in markerObjectsRelay) {
+					relayMarkerObjects.Value.GetComponent<AHMapMarker> ().Show ();
 				}
 			} else {
-				foreach (KeyValuePair<Vessel, AHMapMarker> relayMarkers in markersRelay) {
-					relayMarkers.Value.Hide ();
+				foreach (KeyValuePair<Vessel, GameObject> relayMarkerObjects in markerObjectsRelay) {
+					relayMarkerObjects.Value.GetComponent<AHMapMarker> ().Hide ();
 				}
 			}
 		}

--- a/Source/AntennaHelper/AHLinkUtil.cs
+++ b/Source/AntennaHelper/AHLinkUtil.cs
@@ -111,7 +111,7 @@ namespace AntennaHelper
 		public static void UpdateRelayVessels ()
 		{
 			potentialRelays = new List<RelayVessel> ();
-			foreach (Vessel v in FlightGlobals.Vessels.FindAll (v => (v.Connection != null) && (v != FlightGlobals.ActiveVessel))) {
+			foreach (Vessel v in FlightGlobals.Vessels.FindAll (v => (v.Connection != null))) {
 				double relayPower = AHUtil.GetActualVesselPower (v, true);
 				if (relayPower > 0) {
 					potentialRelays.Add (new RelayVessel (v));

--- a/Source/AntennaHelper/AHLinkUtil.cs
+++ b/Source/AntennaHelper/AHLinkUtil.cs
@@ -102,6 +102,14 @@ namespace AntennaHelper
 			_dsn.distanceOffset = home.Radius;
 			_dsn.name = /*"DSN"*/Localizer.Format ("#autoLOC_AH_0014");
 
+			//				Debug.Log ("[AH] dsn distance offset : " + _dsn.distanceOffset);
+			//				Debug.Log ("[AH] static dsn relay constructed");
+
+			UpdateRelayVessels ();
+		}
+
+		public static void UpdateRelayVessels ()
+		{
 			potentialRelays = new List<RelayVessel> ();
 			foreach (Vessel v in FlightGlobals.Vessels.FindAll (v => (v.Connection != null) && (v != FlightGlobals.ActiveVessel))) {
 				double relayPower = AHUtil.GetActualVesselPower (v, true);
@@ -109,8 +117,6 @@ namespace AntennaHelper
 					potentialRelays.Add (new RelayVessel (v));
 				}
 			}
-			//				Debug.Log ("[AH] dsn distance offset : " + _dsn.distanceOffset);
-			//				Debug.Log ("[AH] static dsn relay constructed");
 		}
 
 		public static RelayVessel GetRelayVessel (Vessel v)

--- a/Source/AntennaHelper/AHTrackingStation.cs
+++ b/Source/AntennaHelper/AHTrackingStation.cs
@@ -287,7 +287,7 @@ namespace AntennaHelper
 		{
 			HideCircles ();
 
-			if (targetPid == "") {
+			if (targetPid == "" || !listMarkers.ContainsKey (targetPid)) {
 				return;
 			}
 
@@ -342,7 +342,7 @@ namespace AntennaHelper
 			GUILayout.BeginVertical ();
 
 			string transmitterName = "";
-			if (targetPid != "") {
+			if (targetPid != "" && listShipTransmitter.ContainsKey (targetPid)) {
 				transmitterName = listShipTransmitter [targetPid] ["name"];
 			}
 

--- a/Source/AntennaHelper/AHTrackingStation.cs
+++ b/Source/AntennaHelper/AHTrackingStation.cs
@@ -144,6 +144,7 @@ namespace AntennaHelper
 				DestroyMarkers ();
 			}
 
+			AHShipList.ParseFlyingVessel (true);
 			GetListsShip ();
 			CreateMarkers ();
 


### PR DESCRIPTION
This is a set of fixes for several exceptions that I noticed while using AH:

* A NullReferenceException after launching, reverting, and launching again, caused by the `Relay.potentialRelays` list having outdated information.
* Endless NullReferenceExceptions in the tracking station after recovering a vessel, caused by `AHShipList.listFlyingVessel` having outdated information.
* Endless KeyNotFoundExceptions in the tracking station when AH is open and the selected vessel is an asteroid or EVA kerbal, caused by trying to lookup a marker that doesn't exist.
* NullReferenceExceptions when leaving the flight scene, caused by accessing fields of `AHMapMarker` components that have already been destroyed.  (This one was only on the dev branch after the v1.0.4 release.)